### PR TITLE
Filter products by category

### DIFF
--- a/components/filter.js
+++ b/components/filter.js
@@ -1,8 +1,13 @@
-import { useEffect, useRef, useState } from 'react'
-import { getCategories } from '../data/products'
-import { Input, Select } from './form-elements'
+import { useEffect, useRef, useState } from "react";
+import { getCategories } from "../data/products";
+import { Input, Select } from "./form-elements";
 
-export default function Filter({ productCount, onSearch, locations }) {
+export default function Filter({
+  productCount,
+  onSearch,
+  locations,
+  categories,
+}) {
   const refEls = {
     location: useRef(),
     category: useRef(),
@@ -11,71 +16,69 @@ export default function Filter({ productCount, onSearch, locations }) {
     order_by: useRef(),
     direction: useRef(),
     number_sold: useRef(),
-  }
+  };
 
-  const [showFilters, setShowFilters] = useState(false)
-  const [query, setQuery] = useState('')
-  const [categories, setCategories] = useState([{id: 1, name: 'Apples'}, {id: 2, name: 'Oranges'}, {id: 3, name: 'Lemons'}])
-  const [direction, setDirection] = useState('asc')
+  const [showFilters, setShowFilters] = useState(false);
+  const [query, setQuery] = useState("");
+  const [direction, setDirection] = useState("asc");
   const clear = () => {
     for (let ref in refEls) {
-      if (ref === 'direction') {
-        refEls[ref].current.checked = false
-        setDirection('asc')
+      if (ref === "direction") {
+        refEls[ref].current.checked = false;
+        setDirection("asc");
       } else if (["min_price", "name"].includes(ref)) {
-        refEls[ref].current.value = ""
-      }
-      else {
-        refEls[ref].current.value = 0
+        refEls[ref].current.value = "";
+      } else {
+        refEls[ref].current.value = 0;
       }
     }
-    onSearch('')
-  }
+    onSearch("");
+  };
   const orderByOptions = [
     {
-      id: 'price',
-      name: 'Price'
+      id: "price",
+      name: "Price",
     },
     {
-      id: 'name',
-      name: 'Name'
-    }
-  ]
+      id: "name",
+      name: "Name",
+    },
+  ];
 
   const directionOptions = [
     {
-      name: 'direction',
-      label: 'asc'
+      name: "direction",
+      label: "asc",
     },
     {
-      name: 'direction',
-      label: 'desc'
+      name: "direction",
+      label: "desc",
     },
-  ]
+  ];
 
   useEffect(() => {
     if (query) {
-      onSearch(query)
+      onSearch(query);
     }
-  }, [query])
+  }, [query]);
 
   const buildQuery = (key, value) => {
     if (value && value !== "0") {
-      return `${key}=${value}&`
+      return `${key}=${value}&`;
     }
-    return ""
-  }
+    return "";
+  };
 
   const filter = () => {
-    let newQuery = ""
+    let newQuery = "";
     for (let refEl in refEls) {
-      newQuery += buildQuery(refEl, refEls[refEl].current.value)
+      newQuery += buildQuery(refEl, refEls[refEl].current.value);
     }
-    setQuery(newQuery)
-  }
+    setQuery(newQuery);
+  };
 
   return (
-    <div className='level'>
+    <div className="level">
       <div className="level-left">
         <div className="level-item">
           <p className="subtitle is-5">
@@ -100,7 +103,9 @@ export default function Filter({ productCount, onSearch, locations }) {
       </div>
       <div className="level-right">
         <div className="level-item">
-          <div className={`dropdown is-right ${showFilters ? 'is-active' : ''}`}>
+          <div
+            className={`dropdown is-right ${showFilters ? "is-active" : ""}`}
+          >
             <div className="dropdown-trigger">
               <button
                 className="button"
@@ -110,7 +115,7 @@ export default function Filter({ productCount, onSearch, locations }) {
               >
                 <span>Filter Products</span>
                 <span className="icon is-small">
-                <i className="fas fa-filter"></i>
+                  <i className="fas fa-filter"></i>
                 </span>
               </button>
             </div>
@@ -141,7 +146,6 @@ export default function Filter({ productCount, onSearch, locations }) {
                     addlClass="is-horizontal"
                     refEl={refEls.min_price}
                   />
-
                 </div>
                 <hr className="dropdown-divider"></hr>
                 <div className="dropdown-item">
@@ -169,9 +173,9 @@ export default function Filter({ productCount, onSearch, locations }) {
                           ref={refEls.direction}
                           onChange={(event) => {
                             if (event.target.checked) {
-                              setDirection('desc')
+                              setDirection("desc");
                             } else {
-                              setDirection('asc')
+                              setDirection("asc");
                             }
                           }}
                         />
@@ -201,5 +205,5 @@ export default function Filter({ productCount, onSearch, locations }) {
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -1,57 +1,74 @@
-import { useEffect, useState } from 'react'
-import Filter from '../../components/filter'
-import Layout from '../../components/layout'
-import Navbar from '../../components/navbar'
-import { ProductCard } from '../../components/product/card'
-import { getProducts } from '../../data/products'
+import { useEffect, useState } from "react";
+import Filter from "../../components/filter";
+import Layout from "../../components/layout";
+import Navbar from "../../components/navbar";
+import { ProductCard } from "../../components/product/card";
+import { getProducts } from "../../data/products";
 
 export default function Products() {
-  const [products, setProducts] = useState([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [loadingMessage, setLoadingMessage] = useState("Loading products...")
-  const [locations, setLocations] = useState([])
+  const [products, setProducts] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [loadingMessage, setLoadingMessage] = useState("Loading products...");
+  const [locations, setLocations] = useState([]);
+  const [categories, setCategories] = useState([]);
 
   useEffect(() => {
-    getProducts().then(data => {
-      if (data) {
+    getProducts()
+      .then((data) => {
+        if (data) {
+          const locationData = [
+            ...new Set(data.map((product) => product.location)),
+          ];
+          const locationObjects = locationData.map((location) => ({
+            id: location,
+            name: location,
+          }));
+          const categoryData = [...data.map((product) => product.category)];
+          const uniqueCategories = new Map();
+          for (const category of categoryData) {
+            uniqueCategories.set(category.id, category);
+          }
+          const categoryObjects = [...uniqueCategories.values()];
 
-        const locationData = [...new Set(data.map(product => product.location))]
-        const locationObjects = locationData.map(location => ({
-          id: location,
-          name: location
-        }))
-
-        setProducts(data)
-        setIsLoading(false)
-        setLocations(locationObjects)
-      }
-    })
-    .catch(err => {
-      setLoadingMessage(`Unable to retrieve products. Status code ${err.message} on response.`)
-    })
-  }, [])
+          setProducts(data);
+          setIsLoading(false);
+          setLocations(locationObjects);
+          setCategories(categoryObjects);
+        }
+      })
+      .catch((err) => {
+        setLoadingMessage(
+          `Unable to retrieve products. Status code ${err.message} on response.`
+        );
+      });
+  }, []);
 
   const searchProducts = (event) => {
-    getProducts(event).then(productsData => {
+    getProducts(event).then((productsData) => {
       if (productsData) {
-        setProducts(productsData)
+        setProducts(productsData);
       }
-    })
-  }
+    });
+  };
 
-  if (isLoading) return <p>{loadingMessage}</p>
+  if (isLoading) return <p>{loadingMessage}</p>;
 
   return (
     <>
-      <Filter productCount={products.length} onSearch={searchProducts} locations={locations} />
+      <Filter
+        productCount={products.length}
+        onSearch={searchProducts}
+        locations={locations}
+        categories={categories}
+      />
 
       <div className="columns is-multiline">
-        {products.map(product => (
+        {products.map((product) => (
           <ProductCard product={product} key={product.id} />
         ))}
       </div>
     </>
-  )
+  );
 }
 
 Products.getLayout = function getLayout(page) {
@@ -60,5 +77,5 @@ Products.getLayout = function getLayout(page) {
       <Navbar />
       {page}
     </Layout>
-  )
-}
+  );
+};


### PR DESCRIPTION
## What?
- Added ability for users to filter product results by category

## Why?
- Gives the ability for users on the front end of our application to filter product results by category

## How?
- Passed categories to the filter component as a prop, the same way locations are being passed in.
- Fetched categories from backend, created a unique Map of category objects, and pass them in to the filter component, similar to locations

## Testing?
1. Start up the front end and back end dev servers 
2. Navigate to /products on the front end
3. Click the "Filter Products" button
4. Click the "Filter by Category" dropdown
5. The 3 categories for the products should appear, in this case Auto, Clothes, and Tools
6. Click one of the categories, then click the green "Filter" button
7. Only the products that have the category chosen should appear

## Screenshots (optional)

## Anything Else?
There is a lot of formatting BS that was created by prettier that are not actual changes