### PR TITLE
fix: same user profile always returned

### DIFF
--- a/data/auth.js
+++ b/data/auth.js
@@ -21,7 +21,7 @@ export function register(user) {
 }
 
 export function getUserProfile() {
-  return fetchWithResponse('my-profile', {
+  return fetchWithResponse('profile', {
     headers: {
       Authorization: `Token ${localStorage.getItem('token')}`,
     }

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -16,10 +16,11 @@ export default function Profile() {
         setProfile(profileData)
       }
     })
-  }, [])
+  }, [setProfile])
 
   return (
     <>
+      <h1>{profile.id}</h1>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -20,7 +20,7 @@ export default function Profile() {
 
   return (
     <>
-      <h1>{profile.id}</h1>
+      <h1>{profile.user.first_name} {profile.user.last_name}</h1>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {


### PR DESCRIPTION
## What?
- Small edits to cause the profile page to render properly and added text for testing

## Why?
- The same user profile would be displayed every time, as well as an issue where the profile page would get a 500 error upon rendering

## How?
- `getUserProfile()` in auth.js was trying to fetch `my-profile` when it should have been fetching `profile`. This has been fixed.

## Testing?
- Merge update from backend, then log in, click on the user icon, click profile from the dropdown menu. The user's id is displayed at the top - log out, then back in to a different user, then go to the profile again to ensure the number has changed. This will not work unless the backend api is up to date first.

## Screenshots (optional)

## Anything Else?
