### PR TITLE
fix: standardize payment types endpoint naming

### DIFF
--- a/data/payment-types.js
+++ b/data/payment-types.js
@@ -1,29 +1,29 @@
 import { fetchWithResponse, fetchWithoutResponse } from "./fetcher";
 
 export function getPaymentTypes() {
-  return fetchWithResponse('payment-types', {
+  return fetchWithResponse(`paymenttypes`, {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
-  })
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
+  });
 }
 
 export function addPaymentType(paymentType) {
-  return fetchWithResponse(`payment-types`, {
-    method: 'POST',
+  return fetchWithResponse(`paymenttypes`, {
+    method: "POST",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify(paymentType)
-  })
+    body: JSON.stringify(paymentType),
+  });
 }
 
 export function deletePaymentType(id) {
-  return fetchWithoutResponse(`payment-types/${id}`, {
-    method: 'DELETE',
+  return fetchWithoutResponse(`paymenttypes/${id}`, {
+    method: "DELETE",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
-  })
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
+  });
 }


### PR DESCRIPTION
## What?
- Updated payment types API endpoint URLs to use /paymenttypes format (without hyphen) to match the backend API routing

## Why?
- Fixed URL mismatch between frontend and backend that was causing payment type requests to fail
The backend API uses /paymenttypes but the frontend was calling /payment-types (with hyphen), resulting in 404 errors

## How?
- Modified payment-types.js to update all API calls:
Changed getPaymentTypes() endpoint from payment-types to paymenttypes
Changed addPaymentType() endpoint from payment-types to paymenttypes
Changed deletePaymentType() endpoint from payment-types/{id} to paymenttypes/{id}

## Testing?
- Payment types now load correctly on the payments page
