### PR TITLE
Bugfix/products added to last closed order/35

### DIFF
--- a/data/orders.js
+++ b/data/orders.js
@@ -1,28 +1,28 @@
-import { fetchWithResponse } from './fetcher'
+import { fetchWithResponse } from "./fetcher";
 
 export function getCart() {
-  return fetchWithResponse('cårt', {
+  return fetchWithResponse("cart", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
-  })
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
+  });
 }
 
 export function getOrders() {
-  return fetchWithResponse('orders', {
+  return fetchWithResponse("orders", {
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`
-    }
-  })
+      Authorization: `Token ${localStorage.getItem("token")}`,
+    },
+  });
 }
 
 export function completeCurrentOrder(orderId, paymentTypeId) {
   return fetchWithResponse(`orders/${orderId}/complete`, {
-    method: 'PUT',
+    method: "PUT",
     headers: {
-      Authorization: `Token ${localStorage.getItem('token')}`,
-      'Content-Type': 'application/json'
+      Authorization: `Token ${localStorage.getItem("token")}`,
+      "Content-Type": "application/json",
     },
-    body: JSON.stringify({paymentTypeId})
-  })
+    body: JSON.stringify({ paymentTypeId }),
+  });
 }

--- a/data/orders.js
+++ b/data/orders.js
@@ -23,6 +23,6 @@ export function completeCurrentOrder(orderId, paymentTypeId) {
       Authorization: `Token ${localStorage.getItem("token")}`,
       "Content-Type": "application/json",
     },
-    body: JSON.stringify({ paymentTypeId }),
+    body: JSON.stringify({ payment_type: paymentTypeId }),
   });
 }


### PR DESCRIPTION
## What?
- Updated body of orders/{orderId}/complete endpoint to be: `payment_type: paymentTypeId` instead of `paymentTypeId: paymentTypeId`
- Changed the getCart endpoint to `cart` instead of `cårt`
- Minor formatting changes that prettier did on its own

## Why?
- The backend is reading payment type information as payment_type, so this change was made to match the convention of the backend

## How?
- 

## Testing?
- Switch to the backend branch for this issue, as well as this branch, and follow the testing instructions in the backend PR

## Screenshots (optional)

## Anything Else?
