### PR TITLE
feat: added containers showing 5 most recent products by category

### DIFF
--- a/components/recents.js
+++ b/components/recents.js
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { ProductCard } from "./product/card";
+import { getProducts } from "../data/products";
+
+export default function RecentProductsBar({ category }) {
+  const [products, setProducts] = useState([]);
+
+  useEffect(() => {
+    getProducts(`category=${category.id}&quantity=5`)
+      .then(setProducts);
+  }, [category]);
+
+  return (
+    <div style={{ position: "relative", marginTop: "2rem", marginBottom: "2rem" }}>
+      {/* Tab in top left */}
+      <div
+        style={{
+          position: "absolute",
+          top: "-1.2rem",
+          left: "1rem",
+          background: "#fff",
+          padding: "0.3rem 1rem",
+          borderRadius: "1rem",
+          borderLeft: "2px solid #ffd600",
+          borderTop: "2px solid #ffd600",
+          borderRight: "2px solid #ffd600",
+          borderBottom: "none",
+          fontWeight: "bold",
+          zIndex: 1,
+        }}
+      >
+        NEW in {category.name}
+      </div>
+      {/* Outlined container */}
+      <div
+        className="columns"
+        style={{
+          border: "2px solid #ffd600",
+          borderRadius: "0.5rem",
+          padding: "1rem",
+          margin: "2px",
+        }}
+      >
+        {products.map((product) => (
+          <ProductCard 
+            product={product} 
+            key={product.id}
+            width="is-one-fifth"
+          />
+        ))}
+      </div>
+    </div>
+  )
+
+}

--- a/pages/products/index.js
+++ b/pages/products/index.js
@@ -2,12 +2,14 @@ import { useEffect, useState } from "react";
 import Filter from "../../components/filter";
 import Layout from "../../components/layout";
 import Navbar from "../../components/navbar";
+import RecentProductsBar from "../../components/recents";
 import { ProductCard } from "../../components/product/card";
 import { getProducts } from "../../data/products";
 
 export default function Products() {
   const [products, setProducts] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [hasFiltered, setHasFiltered] = useState(false);
   const [loadingMessage, setLoadingMessage] = useState("Loading products...");
   const [locations, setLocations] = useState([]);
   const [categories, setCategories] = useState([]);
@@ -34,7 +36,7 @@ export default function Products() {
           setIsLoading(false);
           setLocations(locationObjects);
           setCategories(categoryObjects);
-        }
+        } 
       })
       .catch((err) => {
         setLoadingMessage(
@@ -44,6 +46,8 @@ export default function Products() {
   }, []);
 
   const searchProducts = (event) => {
+    // if event is empty string, no filter has been applied
+    event === "" ? setHasFiltered(false) : setHasFiltered(true);
     getProducts(event).then((productsData) => {
       if (productsData) {
         setProducts(productsData);
@@ -61,12 +65,21 @@ export default function Products() {
         locations={locations}
         categories={categories}
       />
-
-      <div className="columns is-multiline">
-        {products.map((product) => (
-          <ProductCard product={product} key={product.id} />
-        ))}
-      </div>
+      <h1>{hasFiltered ? <div style={{fontWeight: "bold"}}>Products matching filters:</div> : ""}</h1>
+      {
+        hasFiltered ? 
+          <div className="columns is-multiline">
+            {products.map((product) => (
+              <ProductCard product={product} key={product.id} />
+            ))}
+          </div>
+        : 
+          categories.map((category) => (
+            <div key={category.id} >
+              <RecentProductsBar key={category.id} category={category} />
+            </div>
+          ))
+      }
     </>
   );
 }


### PR DESCRIPTION
## What?
- Added a container that shows up on the products page that (if no filters have been applied) 

## Why?
- Adds the requested feature in ticket #28 ; When the user lands on the products page and no filters have been applied, each category will be listed, showing the 5 most recently added products within each category.

## How?
- I added a new component, `RecentProductsBar`, which takes in one parameter, `category`. This parameter is gotten from the `categories` in pages/products/index.js. The parameter is then used to fetch `http://localhost:8000/products?category=${category.id}&quantity=5`. The `quantity=5` query limits the result to 5 items, reducing unnecessary data fetching, and also by design on the backend is already sorted by most recent.

## Testing?
- Log in
- Click 'Products'
- The `RecentProductsBar` for each category should be displayed.
- Add any filter; the normal results page should appear with the correct data.
- Clear the filter, `RecentProductsBar` should reappear

## Screenshots (optional)
<img width="1318" height="592" alt="rpb" src="https://github.com/user-attachments/assets/0bfcd48d-bf82-4d5e-a9b3-d0bd4b143dea" />


## Anything Else?
