### PR TITLE
feat: ratings can be sent to backend

### DIFF
--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -1,24 +1,30 @@
-import { useState, useEffect } from 'react'
-import { rateProduct } from '../../data/products'
-import { RatingsContainer } from './container'
-import { Header } from './header'
+import { useState, useEffect } from "react";
+import { rateProduct } from "../../data/products";
+import { RatingsContainer } from "./container";
+import { Header } from "./header";
 
-export function Ratings({ average_rating, refresh, ratings = [], number_purchased, likes = [] }) {
-  const [productId, setProductId] = useState(0)
+export function Ratings({
+  productId,
+  average_rating,
+  refresh,
+  ratings = [],
+  number_purchased,
+  likes = [],
+}) {
+  // const [productId, setProductId] = useState(0)
   const saveRating = (newRating) => {
-    rateProduct(productId, newRating).then(refresh)
-
-  }
+    rateProduct(productId, newRating).then(refresh);
+  };
 
   useEffect(() => {
     if (ratings.length) {
-      setProductId(ratings[0].product)
+      setProductId(ratings[0].product);
     }
-  }, [ratings])
+  }, [ratings]);
 
   return (
     <div className="tile is-ancestor is-flex-wrap-wrap">
-      <Header 
+      <Header
         averageRating={average_rating}
         ratingsLen={ratings.length}
         numberPurchased={number_purchased}
@@ -26,5 +32,5 @@ export function Ratings({ average_rating, refresh, ratings = [], number_purchase
       />
       <RatingsContainer ratings={ratings} saveRating={saveRating} />
     </div>
-  )
+  );
 }

--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -1,19 +1,17 @@
-import { Rating } from 'react-simple-star-rating'
-import { useState } from 'react'
+import { Rating } from "react-simple-star-rating";
+import { useState } from "react";
 
 export default function RatingForm({ saveRating }) {
-  const [rating, setRating] = useState(0)
-  const [comment, setComment] = useState("")
-  
+  const [rating, setRating] = useState(0);
+  const [comment, setComment] = useState("");
+
   const submitRating = () => {
-    const outOf5 = rating/20
+    const outOf5 = rating;
     saveRating({
       score: outOf5,
-      review: comment
-    })
-  }
-
-
+      review: comment,
+    });
+  };
 
   return (
     <div className="tile is-child ">
@@ -24,16 +22,23 @@ export default function RatingForm({ saveRating }) {
         <div className="media-content">
           <div className="field">
             <p className="control">
-              <textarea className="textarea" placeholder="Add your review" value={comment} onChange={(e) => setComment(e.target.value)}></textarea>
+              <textarea
+                className="textarea"
+                placeholder="Add your review"
+                value={comment}
+                onChange={(e) => setComment(e.target.value)}
+              ></textarea>
             </p>
           </div>
           <div className="field">
             <p className="control">
-              <button className="button" onClick={submitRating}>Post Rating</button>
+              <button className="button" onClick={submitRating}>
+                Post Rating
+              </button>
             </p>
           </div>
         </div>
       </article>
     </div>
-  )
+  );
 }

--- a/pages/products/[id]/index.js
+++ b/pages/products/[id]/index.js
@@ -1,43 +1,48 @@
-import { useRouter } from 'next/router'
-import { useEffect, useState } from 'react'
-import Layout from '../../../components/layout'
-import Navbar from '../../../components/navbar'
-import { Detail } from '../../../components/product/detail'
-import { Ratings } from '../../../components/rating/detail'
-import { getProductById, likeProduct, unLikeProduct } from '../../../data/products'
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import Layout from "../../../components/layout";
+import Navbar from "../../../components/navbar";
+import { Detail } from "../../../components/product/detail";
+import { Ratings } from "../../../components/rating/detail";
+import {
+  getProductById,
+  likeProduct,
+  unLikeProduct,
+} from "../../../data/products";
 
 export default function ProductDetail() {
-  const router = useRouter()
-  const { id } = router.query
-  const [product, setProduct] = useState({})
+  const router = useRouter();
+  const { id } = router.query;
+  const [product, setProduct] = useState({});
 
   const refresh = () => {
-    getProductById(id).then(productData => {
+    getProductById(id).then((productData) => {
       if (productData) {
-        setProduct(productData)
+        setProduct(productData);
       }
-    })
-  }
+    });
+  };
 
   const like = () => {
-    likeProduct(id).then(refresh)
-  }
+    likeProduct(id).then(refresh);
+  };
 
   const unlike = () => {
-    unLikeProduct(id).then(refresh)
-  }
+    unLikeProduct(id).then(refresh);
+  };
 
   useEffect(() => {
     if (id) {
-      refresh()
+      refresh();
     }
-  }, [id])
+  }, [id]);
 
   return (
     <div className="columns is-centered">
       <div className="column">
-        <Detail product={product} like={like} unlike={unlike}/>
+        <Detail product={product} like={like} unlike={unlike} />
         <Ratings
+          productId={product.id}
           refresh={refresh}
           number_purchased={product.number_purchased}
           ratings={product.ratings}
@@ -46,7 +51,7 @@ export default function ProductDetail() {
         />
       </div>
     </div>
-  )
+  );
 }
 
 ProductDetail.getLayout = function getLayout(page) {
@@ -55,5 +60,5 @@ ProductDetail.getLayout = function getLayout(page) {
       <Navbar />
       {page}
     </Layout>
-  )
-}
+  );
+};


### PR DESCRIPTION
## What?
This PR adds functionality to the rating feature in the frontend of our application. Previously, the rating requests were not making it to the backend, now ratings function normally. Added productID as a prop to be able to send it in the URL for requests to the backend.


## Why?
- To enable ratings made on the front end to be able to be sent to the backend so that average rating functionality works.

## How?
#### components/rating/detail.js
- Set up Ratings component to expect product ID as a prop

#### components/rating/form.js
- Fixed an issue where the rating was returning incorrect values

#### pages/products/[id]/index.js
- Passing product ID as a prop to the Ratings component on this page

## Testing?
- Run git fetch origin in the terminal to fetch all branches
- Run git switch test/product-can-be-rated/17 to switch to this branch
- Ensure backend is using the same branch, then run the backend dev server ```python3 manage.py runserver```
- ```npm run dev``` to run frontend dev server
- In the frontend, navigate to the page of a specific product
- Fill in the star rating for that product, then click the Post Rating button
- Do this a few more times, and you should see the average rating (rounded to 2 decimal places) for that product update in realtime
- The ```bangazonapi_productrating``` table should populate with a new row every time a new rating is added

## Screenshots (optional)
<img width="1365" height="335" alt="Screenshot 2025-07-26 at 1 40 53 PM" src="https://github.com/user-attachments/assets/a95fa3e8-c83c-4d18-a5d7-ab14469702ff" />



## Anything Else?
- The # of reviews on the product page is not functional, but that might be a separate issue ticket. If not, we can create one and I can tackle it later
