### PR TITLE
fix: undefined window on refreshing product page

### DIFF
--- a/components/rating/form.js
+++ b/components/rating/form.js
@@ -1,9 +1,14 @@
 import { Rating } from "react-simple-star-rating";
-import { useState } from "react";
+import { useState, useEffect } from "react";
 
 export default function RatingForm({ saveRating }) {
   const [rating, setRating] = useState(0);
+  const [mounted, setMounted] = useState(false);
   const [comment, setComment] = useState("");
+
+  useEffect(() => {
+    setMounted(true);
+  }, [])
 
   const submitRating = () => {
     const outOf5 = rating;
@@ -17,7 +22,7 @@ export default function RatingForm({ saveRating }) {
     <div className="tile is-child ">
       <article className="media box">
         <figure className="media-left">
-          <Rating onClick={setRating} ratingValue={rating} />
+          {mounted && <Rating onClick={setRating} ratingValue={rating} />}
         </figure>
         <div className="media-content">
           <div className="field">


### PR DESCRIPTION
## What?
- This PR fixes an issue where the browser would throw a 'window is undefined' error upon refreshing a product's detail page.

## Why?
- To make the site more user friendly and consistent

## How?
- Added a new state, `mounted`, in `RatingForm`, which is updated to `true` in a `useEffect` call, and then checked for before loading the `Rating` component. It took a lot of hunting to figure out which component was causing the issue.

## Testing?
- Navigate to any product's detail page after logging in, and then refresh the page to make sure the client does not get an error.

## Screenshots (optional)

## Anything Else?
- I think this should be a temporary solution as I believe the problem is that the component is loaded before the request headers are sent, as before this fix, you may notice in the network tab on your browser console that the authorization token does not appear in the request headers.