### PR TITLE
fix: profile page errors on refresh

### DIFF
--- a/components/rating/detail.js
+++ b/components/rating/detail.js
@@ -11,7 +11,6 @@ export function Ratings({
   number_purchased,
   likes = [],
 }) {
-  // const [productId, setProductId] = useState(0)
   const saveRating = (newRating) => {
     rateProduct(productId, newRating).then(refresh);
   };

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -20,7 +20,7 @@ export default function Profile() {
 
   return (
     <>
-      <h1>{profile.user.first_name} {profile.user.last_name}</h1>
+      <h1>{profile?.user?.first_name} {profile?.user?.last_name}</h1>
       <CardLayout title="Favorite Stores" width="is-full">
         <div className="columns is-multiline">
           {
@@ -56,7 +56,7 @@ export default function Profile() {
         <div className="columns is-multiline">
           {
             profile.likes?.map(product => (
-              <ProductCard product={product.product} key={product.product.id} width="is-one-third" />
+              <ProductCard product={product} key={product.id} width="is-one-third" />
             ))
           }
         </div>

--- a/pages/profile.js
+++ b/pages/profile.js
@@ -56,7 +56,7 @@ export default function Profile() {
         <div className="columns is-multiline">
           {
             profile.likes?.map(product => (
-              <ProductCard product={product} key={product.id} width="is-one-third" />
+              <ProductCard product={product.product} key={product.product.id} width="is-one-third" />
             ))
           }
         </div>


### PR DESCRIPTION
## What?
- The profile page was getting a TypeError: `first_name is undefined` upon refreshing the page. This PR fixes that error.

## Why?
- To solve an error

## How?
- Added checks to the `profile` and `user` objects to skip attempting to render them until they are loaded

## Testing?
- Once logged in, navigate to the profile page and refresh the page after loading to ensure no errors.

## Screenshots (optional)

## Anything Else?
